### PR TITLE
Support simple Swagger definition types.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -29,9 +29,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Faithlife.Analyzers" Version="1.0.7" PrivateAssets="All" IncludeAssets="runtime; build; native; contentfiles; analyzers" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.333" PrivateAssets="All" IncludeAssets="runtime; build; native; contentfiles; analyzers" />
+    <PackageReference Include="Faithlife.Analyzers" Version="1.2.1" PrivateAssets="All" IncludeAssets="runtime; build; native; contentfiles; analyzers" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.376" PrivateAssets="All" IncludeAssets="runtime; build; native; contentfiles; analyzers" />
   </ItemGroup>
 
 </Project>

--- a/src/Facility.Definition.Swagger/Facility.Definition.Swagger.csproj
+++ b/src/Facility.Definition.Swagger/Facility.Definition.Swagger.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Facility.Definition" Version="2.3.0" />
+    <PackageReference Include="Facility.Definition" Version="2.7.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="YamlDotNet" Version="5.2.1" />
   </ItemGroup>
-
 </Project>

--- a/src/Facility.Definition.Swagger/SwaggerConversion.cs
+++ b/src/Facility.Definition.Swagger/SwaggerConversion.cs
@@ -458,6 +458,14 @@ namespace Facility.Definition.Swagger
 							if (IsFacilityError(resolvedSchema))
 								return "error";
 
+							var resolvedType = resolvedSchema.Value.Type ?? SwaggerSchemaType.Object;
+							if ((resolvedType == SwaggerSchemaType.String || resolvedType == SwaggerSchemaType.Number ||
+								resolvedType == SwaggerSchemaType.Integer || resolvedType == SwaggerSchemaType.Boolean) &&
+								TryGetFacilityTypeName(resolvedSchema.Value, position) is string aliasType)
+							{
+								return aliasType;
+							}
+
 							var resultOfType = TryGetFacilityResultOfType(resolvedSchema, position);
 							if (resultOfType != null)
 								return $"result<{resultOfType}>";


### PR DESCRIPTION
When converting from a Swagger input to an FSD output, an error is thrown because CoverLink is not found.  This is because CoverLink is never created as a Dto with [AddServiceDto](https://github.com/FacilityApi/FacilitySwagger/blob/2b6a3e7ea58dac214b25c43242695b6bf3cae578/src/Facility.Definition.Swagger/SwaggerConversion.cs#L92-L102) because it is not an `object` type.

* Update package dependencies.
* Support references to definitions that are simple FSD types and not objects.
* Would be nice if we could surface the definition `description` to the `ServiceFieldInfo`, but it is not currently structured to support that. 

Example Swagger [definition](https://isbndb.com/modules/isbndb_api_docs/swagger_v2.6.json)

```
...
  "definitions": {
     ...
    "Book": {
      "type": "object",
      "properties": {
        "title": {
          "type": "string"
        },
        "image": {
          "$ref": "#/definitions/CoverLink"
        },
        ...
    "CoverLink": {
      "type": "string",
      "description": "The link to the cover image"
    },
...
```

Should just convert to `string` in the generated FSD

```
 image: string;
```